### PR TITLE
Fix error message for missing project id var in os

### DIFF
--- a/pktables.py
+++ b/pktables.py
@@ -14,7 +14,7 @@ if PACKETKEY is None:
     raise RuntimeError("PACKET_API_AUTH_TOKEN or PACKETKEY(deprecated) env var not set")
 
 if PROJECTID is None:
-    raise RuntimeError("PACKET_PROJECT_ID or PROJECTID(deprecated) env var not set")
+    raise RuntimeError("PACKET_PROJECT or PROJECTID(deprecated) env var not set")
 
 RULESFILE = os.environ.get("RULESFILE", "/data/pktables.rules")
 CHAIN = os.environ.get("CHAIN", "PKTABLES")


### PR DESCRIPTION
https://github.com/packethost/pktables/blob/af9cb367d93f6603266d436931ce9fe553f9a761/pktables.py#L12 asks for PACKET_PROJECT as the OS var

https://github.com/packethost/pktables/blob/af9cb367d93f6603266d436931ce9fe553f9a761/pktables.py#L17 throws error message PACKET_PROJECT_ID

These should match up.